### PR TITLE
Add missing Imports to DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Depends:
 Imports:
     rJava,
     rjson,
-    RCurl
+    RCurl,
+    XML
 ByteCompile: yes
 Description: Send emails with attachments via R.
 URL: http://github.com/trinker/gmailR


### PR DESCRIPTION
This PR adds the missing package imports listed in the NAMESPACE to the DESCRIPTION file. Checkout http://cran.r-project.org/doc/manuals/R-exts.html#Package-Dependencies for more info.
